### PR TITLE
Test Against Larger Messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ test:
 	docker compose exec kafka kafka-topics --bootstrap-server kafka:29092 --create --topic vault.infra.external.kafka_connect.default.status --partitions 5 --config cleanup.policy=compact
 	docker compose exec kafka kafka-topics --bootstrap-server kafka:29092 --create --topic vault.api.v1.accounts.account.created
 	docker compose exec kafka kafka-topics --bootstrap-server kafka:29092 --create --topic vault.api.v1.audit_logs.audit_log.created
-	docker compose exec kafka /bin/sh -c "echo 'Hello, world!' | kafka-console-producer --topic vault.api.v1.audit_logs.audit_log.created --bootstrap-server kafka:29092"
-
+	docker compose exec kafka kafka-configs --bootstrap-server kafka:29092 --alter --entity-type topics --entity-name vault.api.v1.audit_logs.audit_log.created --add-config max.message.bytes=4096000
+	docker compose exec kafka /bin/sh -c "python /usr/local/bin/data-gen.py -c 30_000 -s 640 -r 3_750_000 | kafka-console-producer --topic vault.api.v1.audit_logs.audit_log.created --bootstrap-server kafka:29092 --producer-property max.request.size=4096000"
 	docker compose exec artemis /var/lib/artemis-instance/bin/artemis queue create --user=artemis --password=artemis --name=vault.api.v1.accounts.account.created --silent --auto-create-address
 	docker compose exec artemis /var/lib/artemis-instance/bin/artemis queue create --user=artemis --password=artemis --name=vault.api.v1.audit_logs.audit_log.created --silent --auto-create-address
 

--- a/azure-servicebus-sink-connector/Makefile
+++ b/azure-servicebus-sink-connector/Makefile
@@ -5,3 +5,4 @@ build:
 
 clean:
 	docker compose run --rm mvn -B clean
+	docker compose down -t 0

--- a/azure-servicebus-sink-connector/src/main/java/io/cbdq/AzureServiceBusSinkConnector.java
+++ b/azure-servicebus-sink-connector/src/main/java/io/cbdq/AzureServiceBusSinkConnector.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class AzureServiceBusSinkConnector extends SinkConnector {
 
-    private static final Logger log = LoggerFactory.getLogger(AzureServiceBusSinkTask.class);
+    private static final Logger log = LoggerFactory.getLogger(AzureServiceBusSinkConnector.class);
     private Map<String, String> configProperties;
 
     @Override

--- a/azure-servicebus-sink-connector/src/main/java/io/cbdq/AzureServiceBusSinkTask.java
+++ b/azure-servicebus-sink-connector/src/main/java/io/cbdq/AzureServiceBusSinkTask.java
@@ -90,19 +90,18 @@ public class AzureServiceBusSinkTask extends SinkTask {
         try {
             Message message;
 
-            if (envelope.value() instanceof byte[]) {
+            if (envelope.value() instanceof byte[] data) {
                 BytesMessage bytesMessage = jmsSession.createBytesMessage();
-                bytesMessage.writeBytes((byte[]) envelope.value());
+                bytesMessage.writeBytes(data);
                 message = bytesMessage;
-            } else if (envelope.value() instanceof String) {
-                message = jmsSession.createTextMessage((String) envelope.value());
+            } else if (envelope.value() instanceof String string) {
+                message = jmsSession.createTextMessage(string);
             } else {
                 log.error("Unsupported record value type: {}", envelope.value().getClass());
                 return;
             }
 
             producer.send(message);
-            log.debug("Successfully sent message to JMS topic {}", kafkaTopic);
         } catch (JMSException e) {
             throw new RetriableException("Failed to send message to JMS topic " + kafkaTopic, e);
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       KAFKA_LISTENERS: 'INTERNAL://kafka:29092,CONTROLLER://kafka:29093,EXTERNAL://0.0.0.0:9092'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT'
       KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+      KAFKA_MAX_REQUEST_SIZE: 4194352
       KAFKA_NODE_ID: 1
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_PROCESS_ROLES: 'broker,controller'
@@ -68,6 +69,8 @@ services:
     image: confluentinc/cp-kafka:7.6.2
     ports:
       - 9092:9092
+    volumes:
+      - "./tests/resources/scripts/data-gen.py:/usr/local/bin/data-gen.py"
 
   sut:
     build: sut

--- a/tests/resources/pulumi/__main__.py
+++ b/tests/resources/pulumi/__main__.py
@@ -16,8 +16,8 @@ namespace = azure_native.servicebus.Namespace(
     namespace_name=f'{resource_name}-sbus-01',
     resource_group_name=resource_group.name,
     sku={
-        'name': azure_native.servicebus.SkuName.STANDARD,
-        'tier': azure_native.servicebus.SkuTier.STANDARD
+        'name': azure_native.servicebus.SkuName.PREMIUM,
+        'tier': azure_native.servicebus.SkuTier.PREMIUM
     }
 )
 
@@ -33,7 +33,8 @@ for topic_name in topic_names:
         topic_name,
         namespace_name=namespace.name,
         resource_group_name=resource_group.name,
-        topic_name=topic_name
+        topic_name=topic_name,
+        max_message_size_in_kilobytes=4096
     )
 
 subscription = azure_native.servicebus.Subscription(

--- a/tests/resources/scripts/data-gen.py
+++ b/tests/resources/scripts/data-gen.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""
+Generate test data for injecting into a Kafka topic.
+"""
+import argparse
+import datetime
+import json
+import logging
+import os
+import sys
+
+from random import choice
+from string import ascii_uppercase
+
+MIN_MESSAGE_SIZE = 96
+PROG = os.path.basename(sys.argv[0]).removesuffix('.py')
+logging.basicConfig()
+logger = logging.getLogger(PROG)
+
+
+class DataGenerator:
+    """
+    A class to generate random data as JSON records.
+
+    Parameters
+    ----------
+    count : int
+        The number of records to be generated.
+    size : int
+        The size of reach record.
+    large_message_size : int
+        If a value other than zero is provided, then this will be the
+        size of a message that will be generated randomly as one of the
+        "count" messages.  This is to excercise checking that larger
+        messages can be handled.
+    """
+    def __init__(self, count: int, size: int, large_message_size=0) -> None:
+        """Create a DataGenerator object."""
+        self.count = count
+        self.size = size
+        self.large_message_size = large_message_size
+
+    def print(self) -> None:
+        """Print JSON records."""
+        instance = 0
+
+        if self.large_message_size:
+            random_large_message = choice(range(1, self.count))
+        else:
+            random_large_message = 0
+
+        while instance < self.count:
+            instance += 1
+            record = {
+                'instance': instance,
+                'timestamp': datetime.datetime.utcnow().isoformat(),
+                'payload': ''
+            }
+
+            json_record = json.dumps(record)
+
+            if instance == random_large_message:
+                payload_size = self.large_message_size
+            else:
+                payload_size = self.size - len(json_record)
+
+            payload = ''.join(
+                choice(ascii_uppercase) for i in range(payload_size)
+            )
+            record['payload'] = payload
+            print(json.dumps(record))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog=PROG,
+        description='Generate test data for injecting into a Kafka topic.'
+    )
+    parser.add_argument('-c', '--count',
+                        help='The number of records to create.',
+                        required=True,
+                        type=int)
+    parser.add_argument('-s', '--size',
+                        help='The size (in bytes) for each record.',
+                        required=True,
+                        type=int)
+    parser.add_argument('-r', '--random-large-message-size',
+                        help='The size of a randomly large message.',
+                        default=0,
+                        type=int)
+
+    args = parser.parse_args()
+
+    if args.count <= 0:
+        message = f'Count ({args.count}) must be a positive integer.'
+        logger.error(message)
+        sys.exit(2)
+
+    if args.size < MIN_MESSAGE_SIZE:
+        message = f'Size ({args.size}) must be at least {MIN_MESSAGE_SIZE}.'
+        logger.error(message)
+        sys.exit(2)
+
+    if args.random_large_message_size and args.random_large_message_size <= args.size:
+        logger.error('Large message size must be larger than the default message size.')
+        sys.exit(2)
+
+    dg = DataGenerator(args.count, args.size, args.random_large_message_size)
+    dg.print()


### PR DESCRIPTION
This PR adds changes that make the shape of the data a bit more testing (the number and size of the records, with one record at 3.75MB to check the handling of larger messages).  It also tidies up some more gripes from SonarQube.