### PR TITLE
Update Qpid JMS Client & Add Prometheus Metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ test:
 	curl -X POST -H "Content-Type: application/json" \
 		--data '{"name": "azure-servicebus-sink-connector", "config": {"azure.servicebus.connection.string": "Endpoint=amqp://artemis/;SharedAccessKeyName=artemis;SharedAccessKey=artemis", "connector.class": "io.cbdq.AzureServiceBusSinkConnector", "tasks.max": "1", "topic.rename.format": "replicated-${topic}", "topics": "vault.api.v1.accounts.account.created,vault.api.v1.audit_logs.audit_log.created", "retry.max.attempts": "5", "retry.wait.time.ms": "1000", "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter", "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter", "consumer.override.auto.offset.reset": "earliest"}}' \
 		http://localhost:8083/connectors
+	tests/resources/poll-until-complete.sh
 
 trivy:
 	trivy image --severity HIGH,CRITICAL --ignore-unfixed kc-connectors:latest

--- a/azure-servicebus-sink-connector/Makefile
+++ b/azure-servicebus-sink-connector/Makefile
@@ -6,3 +6,7 @@ build:
 clean:
 	docker compose run --rm mvn -B clean
 	docker compose down -t 0
+
+dependency_tree:
+	docker compose run --rm mvn clean install
+	docker compose run --rm mvn dependency:tree -X

--- a/azure-servicebus-sink-connector/README.md
+++ b/azure-servicebus-sink-connector/README.md
@@ -13,6 +13,8 @@ Please note the following:
 
 - `azure.servicebus.connection.string`: The connection string for the Azure
   Service Bus instance to connect and authenticate with.
+- `prometheus.port`:  The port for the Prometheus HTTP server to run on.
+  Default is 9400.
 - `retry.max.attempts`: The maximum number of attempts to connect to the ASB
   instance. Default is 3.
 - `retry.wait.time.ms`: The time (in milliseconds) to wait between retries to

--- a/azure-servicebus-sink-connector/README.md
+++ b/azure-servicebus-sink-connector/README.md
@@ -13,7 +13,7 @@ Please note the following:
 
 - `azure.servicebus.connection.string`: The connection string for the Azure
   Service Bus instance to connect and authenticate with.
-- `prometheus.port`:  The port for the Prometheus HTTP server to run on.
+- `prometheus.port`: The port for the Prometheus HTTP server to run on.
   Default is 9400.
 - `retry.max.attempts`: The maximum number of attempts to connect to the ASB
   instance. Default is 3.

--- a/azure-servicebus-sink-connector/pom.xml
+++ b/azure-servicebus-sink-connector/pom.xml
@@ -20,7 +20,7 @@
         <java.version>17</java.version>
         <kafka.version>3.8.1</kafka.version>
         <qpid-jms-client.version>1.12.0</qpid-jms-client.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.16</slf4j.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
         <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>

--- a/azure-servicebus-sink-connector/pom.xml
+++ b/azure-servicebus-sink-connector/pom.xml
@@ -21,6 +21,8 @@
         <kafka.version>3.8.1</kafka.version>
         <qpid-jms-client.version>2.6.1</qpid-jms-client.version>
         <slf4j.version>2.0.16</slf4j.version>
+        <cucumber.version>7.14.0</cucumber.version>
+        <prometheus.version>1.3.4</prometheus.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
         <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
@@ -29,6 +31,21 @@
 
     <!-- Dependencies -->
     <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-core</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
@@ -53,14 +70,14 @@
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>7.14.0</version>
+            <version>${cucumber.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>7.14.0</version>
+            <version>${cucumber.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -74,7 +91,7 @@
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-core</artifactId>
-            <version>7.14.0</version>
+            <version>${cucumber.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/azure-servicebus-sink-connector/pom.xml
+++ b/azure-servicebus-sink-connector/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <java.version>17</java.version>
         <kafka.version>3.8.1</kafka.version>
-        <qpid-jms-client.version>1.12.0</qpid-jms-client.version>
+        <qpid-jms-client.version>2.6.1</qpid-jms-client.version>
         <slf4j.version>2.0.16</slf4j.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>

--- a/azure-servicebus-sink-connector/src/main/java/io/cbdq/AzureServiceBusSinkConnectorConfig.java
+++ b/azure-servicebus-sink-connector/src/main/java/io/cbdq/AzureServiceBusSinkConnectorConfig.java
@@ -10,6 +10,9 @@ public class AzureServiceBusSinkConnectorConfig extends AbstractConfig {
     public static final String CONNECTION_STRING_CONFIG = "azure.servicebus.connection.string";
     private static final String CONNECTION_STRING_DOC = "Azure Service Bus connection string.";
 
+    public static final String PROMETHEUS_PORT_CONFIG = "prometheus.port";
+    private static final String PROMETHEUS_PORT_DOC = "The port for the Prometheus HTTP server to run on.";
+
     public static final String RETRY_MAX_ATTEMPTS_CONFIG = "retry.max.attempts";
     private static final String RETRY_MAX_ATTEMPTS_DOC = "Maximum number of retry attempts.";
 
@@ -21,6 +24,7 @@ public class AzureServiceBusSinkConnectorConfig extends AbstractConfig {
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(CONNECTION_STRING_CONFIG, ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, CONNECTION_STRING_DOC)
+            .define(PROMETHEUS_PORT_CONFIG, ConfigDef.Type.INT, 9400, ConfigDef.Importance.MEDIUM, PROMETHEUS_PORT_DOC)
             .define(RETRY_MAX_ATTEMPTS_CONFIG, ConfigDef.Type.INT, 3, ConfigDef.Importance.MEDIUM, RETRY_MAX_ATTEMPTS_DOC)
             .define(RETRY_WAIT_TIME_MS_CONFIG, ConfigDef.Type.INT, 1000, ConfigDef.Importance.MEDIUM, RETRY_WAIT_TIME_MS_DOC)
             .define(TOPIC_RENAME_FORMAT_CONFIG, ConfigDef.Type.STRING, "${topic}", ConfigDef.Importance.HIGH, TOPIC_RENAME_FORMAT_DOC);

--- a/azure-servicebus-sink-connector/src/main/java/io/cbdq/AzureServiceBusSinkTask.java
+++ b/azure-servicebus-sink-connector/src/main/java/io/cbdq/AzureServiceBusSinkTask.java
@@ -8,7 +8,7 @@ import org.apache.qpid.jms.JmsConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import java.util.*;
 
 
@@ -160,7 +160,7 @@ public class AzureServiceBusSinkTask extends SinkTask {
                 attempt++;
                 log.warn("Attempt {} failed to send message to topic {}. Retrying in {} ms...", attempt, kafkaTopic, waitTimeMs, e);
 
-                if (attempt >= maxAttempts || e instanceof javax.jms.IllegalStateException) {
+                if (attempt >= maxAttempts || e instanceof jakarta.jms.IllegalStateException) {
                     log.error("Session or producer error detected. Triggering recovery.");
                     reconnect();
                 }

--- a/azure-servicebus-sink-connector/src/main/java/io/cbdq/AzureServiceBusSinkTask.java
+++ b/azure-servicebus-sink-connector/src/main/java/io/cbdq/AzureServiceBusSinkTask.java
@@ -27,7 +27,6 @@ public class AzureServiceBusSinkTask extends SinkTask {
     private String brokerURL;
     private String username;
     private String password;
-    private HTTPServer prometheusServer;
     private Counter prometheusMessageCounter;
 
     @Override
@@ -86,10 +85,10 @@ public class AzureServiceBusSinkTask extends SinkTask {
                 .name("azure_service_bus_sink_task_message_count_total")
                 .help("The number of messages processed.")
                 .register();
-            prometheusServer = HTTPServer.builder()
+            HTTPServer prometheusServer = HTTPServer.builder()
                 .port(prometheusPort)
                 .buildAndStart();
-            log.info("HTTPServer listening on port http://localhost:" + prometheusPort + "/metrics");
+            log.info("HTTPServer listening on port http://localhost:" + prometheusServer.getPort() + "/metrics");
         } catch (JMSException e) {
             throw new AzureServiceBusSinkException("Failed to initialise JMS client", e);
         } catch (java.io.IOException e) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     image: kc-connectors:latest
     ports:
       - 8083:8083
+      - 9400:9400
 
   kafka:
     container_name: kafka

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "CVE-2024-47535"
+reason = "Only an issue in Windoze."

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,0 @@
-[[IgnoredVulns]]
-id = "CVE-2024-47535"
-reason = "Only an issue in Windoze."

--- a/tests/resources/poll-until-complete.sh
+++ b/tests/resources/poll-until-complete.sh
@@ -4,15 +4,15 @@ URL="http://localhost:9400/metrics"
 TARGET="azure_service_bus_sink_task_message_count_total 40000.0"
 
 while true; do
-    # Fetch the contents of the URL
-    RESPONSE=$(curl -s "$URL")
-    
-    # Check if the response contains the target string
-    if echo "$RESPONSE" | grep -q "$TARGET"; then
-        echo "Target string found: $TARGET"
-        break
-    fi
-    
-    # Wait for a short time before retrying
-    sleep 2
+	# Fetch the contents of the URL
+	RESPONSE=$(curl -s "$URL")
+
+	# Check if the response contains the target string
+	if echo "$RESPONSE" | grep -q "$TARGET"; then
+		echo "Target string found: $TARGET"
+		break
+	fi
+
+	# Wait for a short time before retrying
+	sleep 2
 done

--- a/tests/resources/poll-until-complete.sh
+++ b/tests/resources/poll-until-complete.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+URL="http://localhost:9400/metrics"
+TARGET="azure_service_bus_sink_task_message_count_total 40000.0"
+
+while true; do
+    # Fetch the contents of the URL
+    RESPONSE=$(curl -s "$URL")
+    
+    # Check if the response contains the target string
+    if echo "$RESPONSE" | grep -q "$TARGET"; then
+        echo "Target string found: $TARGET"
+        break
+    fi
+    
+    # Wait for a short time before retrying
+    sleep 2
+done


### PR DESCRIPTION
This PR:
- Bumps qpid-jms-client from 1.12.0 to 2.0.16 (Jakarta).
- Bumps slf4j from 1.7.36 to 2.0.16.
- Adds Prometheus metrics.
- Fixes #23 