### PR TITLE
Bugfix/76 kafka connect rest interface for confluent platform confluent documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## 0.2.7
+
+### Fix
+
+* Use HTTP PUT rather than POST to initialise the connector as it is more idempotent. [Ben Dalling]
+
+
 ## 0.2.7 (2025-01-29)
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fix
 
+* Resolve CVE-2024-1488. [Ben Dalling]
+
 * Use HTTP PUT rather than POST to initialise the connector as it is more idempotent. [Ben Dalling]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.description "A Kafka Connect Sink Connecter for A
 USER root
 
 RUN dnf clean all \
-  && dnf upgrade -y krb5-libs pam \
+  && dnf upgrade -y krb5-libs pam python3-unbound unbound-libs \
   && dnf install -y bind-utils
 
 COPY --chmod=0755 --chown=root:root kccinit.py /usr/local/bin/kccinit.py


### PR DESCRIPTION
Use HTTP PUT rather than POST to initialise the connector as it is more idempotent.  Fixes #76.