### PR TITLE
Bugfix/93 recovery of a renamed topic connection fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## 0.2.9
+
+### Fix
+
+* Ensure that when connections are recovered, the correct destination topic name is used. [Ben Dalling]
+
+
 ## 0.2.9 (2025-02-19)
 
 ### Fix


### PR DESCRIPTION
Ensured the recovery method also uses the renamer functionality.  Fixes #93.