### PR TITLE
Hotfix/0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
 
-## 0.3.1
+## 0.3.2
+
+### Fix
+
+* Resolve CVE-2025-27363. [Ben Dalling]
+
+
+## 0.3.1 (2025-03-18)
 
 ### Fix
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .EXPORT_ALL_VARIABLES:
 
-TAG = 0.3.1
+TAG = 0.3.2
 
 all: lint clean build test
 

--- a/azure-servicebus-sink-connector/pom.xml
+++ b/azure-servicebus-sink-connector/pom.xml
@@ -7,7 +7,7 @@
     <!-- Project Coordinates -->
     <groupId>io.cbdq</groupId>
     <artifactId>azure-servicebus-sink-connector</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
     <packaging>jar</packaging>
 
     <!-- Project Information -->


### PR DESCRIPTION
Rebuild the image to ensure that CVE-2025-27363 is removed.