### PR TITLE
CVE-2025-5914

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,2 @@
 # io.netty:netty-codec-http2 found in based image confluentinc/cp-kafka-connect:7.9.3.
 CVE-2025-55163
-
-# libarchive found in based image confluentinc/cp-kafka-connect:7.9.3.
-CVE-2025-5914

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fix
 
+* CVE-2025-5914. [Ben Dalling]
+
 * CVE-2025-48734. [Ben Dalling]
 
 * CVE-2025-47273. [Ben Dalling]


### PR DESCRIPTION
This was showing up when running Trivy on the MacBook, but not being seen when running on Intel.  Closing down now.