### PR TITLE
Release/1.0.3

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -37,7 +37,7 @@ jobs:
         run: make test
 
       - name: Run Trivy scan
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: kc-connectors:latest
           trivy-config: trivy.yaml

--- a/.github/workflows/periodic-trivy-scan.yml
+++ b/.github/workflows/periodic-trivy-scan.yml
@@ -42,7 +42,7 @@ jobs:
           echo "tag=$semver_tag" >> $GITHUB_OUTPUT
 
       - name: Run Trivy scan and output SARIF
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.35.0
         continue-on-error: true
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ steps.get-tag.outputs.tag }}

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,7 +1,9 @@
 
 # The following vulnerabilities are found in the base image (confluentinc/cp-kafka-connect:8.2.0).
-GHSA-72hv-8253-57qq
+CVE-2025-67030
 CVE-2026-1605
+CVE-2026-25646
 CVE-2026-25679
 CVE-2026-27137
-CVE-2026-27142
+CVE-2026-33870
+CVE-2026-33871

--- a/.trivyignore
+++ b/.trivyignore
@@ -2,3 +2,6 @@
 # The following vulnerabilities are found in the base image (confluentinc/cp-kafka-connect:8.2.0).
 GHSA-72hv-8253-57qq
 CVE-2026-1605
+CVE-2026-25679
+CVE-2026-27137
+CVE-2026-27142

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@
 
 * More vulnerabilities found in the base image. [Ben Dalling]
 
+### Build
+
+* Bump aquasecurity/trivy-action from 0.34.1 to 0.35.0. [dependabot[bot]]
+
+  Bumps [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action) from 0.34.1 to 0.35.0.
+  - [Release notes](https://github.com/aquasecurity/trivy-action/releases)
+  - [Commits](https://github.com/aquasecurity/trivy-action/compare/0.34.1...0.35.0)
+
+  ---
+  updated-dependencies:
+  - dependency-name: aquasecurity/trivy-action
+    dependency-version: 0.35.0
+    dependency-type: direct:production
+    update-type: version-update:semver-minor
+  ...
+
 
 ## 1.0.2 (2026-03-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## Unreleased
+## 1.0.2 (2026-03-11)
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Build
 
+* OSV Scanner not used at the moment. [Ben Dalling]
+
+* Resolve CVE-2026-4111. [Ben Dalling]
+
 * Bump aquasecurity/trivy-action from 0.34.1 to 0.35.0. [dependabot[bot]]
 
   Bumps [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action) from 0.34.1 to 0.35.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## Unreleased
+
+### Fix
+
+* More vulnerabilities found in the base image. [Ben Dalling]
+
+
 ## 1.0.2 (2026-03-11)
 
 ### Fix

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN microdnf clean all \
   && microdnf install -y bind-utils jq python3-pip \
   && microdnf upgrade -y \
     gnupg2 \
+    libarchive \
     libpng \
     openssl-libs \
   && microdnf clean all \

--- a/azure-servicebus-sink-connector/pom.xml
+++ b/azure-servicebus-sink-connector/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.cbdq</groupId>
         <artifactId>azure-servicebus-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>azure-servicebus-sink-connector</artifactId>

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,0 @@
-[[IgnoredVulns]]
-id = "CVE-2024-47535"
-reason = "Only an issue in Windoze."

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.cbdq</groupId>
     <artifactId>azure-servicebus-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>pom</packaging>
 
     <name>Azure Service Bus Connectors</name>


### PR DESCRIPTION
### Fix

* More vulnerabilities found in the base image. [Ben Dalling]

### Build

* OSV Scanner not used at the moment. [Ben Dalling]

* Resolve CVE-2026-4111. [Ben Dalling]

* Bump aquasecurity/trivy-action from 0.34.1 to 0.35.0. [dependabot[bot]]

  Bumps [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action) from 0.34.1 to 0.35.0.
  - [Release notes](https://github.com/aquasecurity/trivy-action/releases)
  - [Commits](https://github.com/aquasecurity/trivy-action/compare/0.34.1...0.35.0)

  ---
  updated-dependencies:
  - dependency-name: aquasecurity/trivy-action
    dependency-version: 0.35.0
    dependency-type: direct:production
    update-type: version-update:semver-minor
  ...