### PR TITLE
Release/1.0.6

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
 
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+		"ghcr.io/devcontainers/features/docker-in-docker:3": {
 			"moby": true,
 			"azureDnsAutoDetection": true,
 			"installDockerBuildx": true,

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,7 +1,7 @@
 
-# The following vulnerabilities are found in the base image (confluentinc/cp-kafka-connect:8.2.0).
+# The following vulnerabilities are found in the base image (confluentinc/cp-kafka-connect:8.2.1).
 #
-#    trivy image --format json confluentinc/cp-kafka-connect:8.2.0 \
+#    trivy image --format json confluentinc/cp-kafka-connect:8.2.1 \
 #    | jq -r '
 #    .Results[]
 #    | select(.Vulnerabilities != null)
@@ -10,31 +10,20 @@
 #    ' \
 #    | sort -u
 #
-CVE-2025-67030
 CVE-2026-1605
 CVE-2026-2332
-CVE-2026-25646
-CVE-2026-25679
-CVE-2026-27135
-CVE-2026-27137
-CVE-2026-32280
-CVE-2026-32281
-CVE-2026-32283
-CVE-2026-33810
-CVE-2026-33811
-CVE-2026-33814
+CVE-2026-33117
+CVE-2026-33845
+CVE-2026-33846
 CVE-2026-33870
 CVE-2026-33871
-CVE-2026-39820
-CVE-2026-39836
-CVE-2026-4111
-CVE-2026-42499
-CVE-2026-42577
+CVE-2026-40356
+CVE-2026-42009
+CVE-2026-42010
 CVE-2026-42579
 CVE-2026-42583
 CVE-2026-42584
 CVE-2026-42587
-CVE-2026-4424
 CVE-2026-4519
 CVE-2026-4786
 CVE-2026-4878

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## Unreleased
+## 1.0.5 (2026-05-14)
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Build
 
+* Bump the base confluentinc/cp-kafka-connect tag from 8.2.0 to 8.2.1. [Ben Dalling]
+
 * Bump ghcr.io/devcontainers/features/docker-in-docker. [dependabot[bot]]
 
   Bumps ghcr.io/devcontainers/features/docker-in-docker from 2.17.0 to 3.0.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 
+## Unreleased
+
+### Build
+
+* Bump ghcr.io/devcontainers/features/docker-in-docker. [dependabot[bot]]
+
+  Bumps ghcr.io/devcontainers/features/docker-in-docker from 2.17.0 to 3.0.1.
+
+  ---
+  updated-dependencies:
+  - dependency-name: ghcr.io/devcontainers/features/docker-in-docker
+    dependency-version: 3.0.1
+    dependency-type: direct:production
+    update-type: version-update:semver-major
+  ...
+
+
 ## 1.0.5 (2026-05-14)
 
 ### Fix

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect:8.2.0
+FROM confluentinc/cp-kafka-connect:8.2.1
 
 LABEL org.opencontainers.image.description="A Kafka Connect Sink Connecter for Azure Service Bus."
 

--- a/azure-servicebus-sink-connector/pom.xml
+++ b/azure-servicebus-sink-connector/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.cbdq</groupId>
         <artifactId>azure-servicebus-parent</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
     </parent>
 
     <artifactId>azure-servicebus-sink-connector</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.cbdq</groupId>
     <artifactId>azure-servicebus-parent</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <packaging>pom</packaging>
 
     <name>Azure Service Bus Connectors</name>


### PR DESCRIPTION
### Build

* Bump the base confluentinc/cp-kafka-connect tag from 8.2.0 to 8.2.1. [Ben Dalling]

* Bump ghcr.io/devcontainers/features/docker-in-docker. [dependabot[bot]]

  Bumps ghcr.io/devcontainers/features/docker-in-docker from 2.17.0 to 3.0.1.

  ---
  updated-dependencies:
  - dependency-name: ghcr.io/devcontainers/features/docker-in-docker
    dependency-version: 3.0.1
    dependency-type: direct:production
    update-type: version-update:semver-major
  ...