### PR TITLE
Release/1.0.7

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
 
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:3": {
+		"ghcr.io/devcontainers/features/docker-in-docker:4": {
 			"moby": true,
 			"azureDnsAutoDetection": true,
 			"installDockerBuildx": true,

--- a/.github/workflows/cd-latest.yml
+++ b/.github/workflows/cd-latest.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/cd-tag.yml
+++ b/.github/workflows/cd-tag.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Display Tag Information
         run: |

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6

--- a/.github/workflows/gitchangelog.yml
+++ b/.github/workflows/gitchangelog.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/gitflow.yml
+++ b/.github/workflows/gitflow.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "RELEASE_CANDIDATE_TAG=$( make tag )" >> $GITHUB_OUTPUT
 
       - name: Git Flow Action
-        uses: cbdq-io/gitflow-action@v1
+        uses: cbdq-io/gitflow-action@1.0.6
         env:
           # Setting this environment variable means we can debug by re-running
           # workflows and ticking "Enable debug logging".

--- a/.github/workflows/gitflow.yml
+++ b/.github/workflows/gitflow.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Retrieve Release Candidate Name
         id: version

--- a/.github/workflows/periodic-trivy-scan.yml
+++ b/.github/workflows/periodic-trivy-scan.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker login to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.trivyignore
+++ b/.trivyignore
@@ -5,6 +5,7 @@
 #    | jq -r '.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | .VulnerabilityID' \
 #    | sort -u
 #
+CVE-2026-33117
 CVE-2026-44249
 CVE-2026-45416
 CVE-2026-45447

--- a/.trivyignore
+++ b/.trivyignore
@@ -18,5 +18,12 @@ GHSA-2r2c-cx56-8933
 GHSA-47qp-hqvx-6r3f
 
 # Fixed in urllib3 2.7.0, but not supported in Python 3.9 which is present on the base image.
+# https://github.com/cbdq-io/kc-connectors/issues/274
 CVE-2026-44431
 CVE-2026-44432
+
+# https://github.com/cbdq-io/kc-connectors/issues/290
+CVE-2026-42579
+CVE-2026-42583
+CVE-2026-42584
+CVE-2026-42587

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,33 +1,20 @@
 
-# The following vulnerabilities are found in the base image (confluentinc/cp-kafka-connect:8.2.1).
+# The following vulnerabilities are found in the base image (confluentinc/cp-kafka-connect:8.2.2).
 #
-#    trivy image --format json confluentinc/cp-kafka-connect:8.2.1 \
-#    | jq -r '
-#    .Results[]
-#    | select(.Vulnerabilities != null)
-#    | .Vulnerabilities[]
-#    | .VulnerabilityID
-#    ' \
+#    trivy image --format json confluentinc/cp-kafka-connect:8.2.2 \
+#    | jq -r '.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[] | .VulnerabilityID' \
 #    | sort -u
 #
-CVE-2026-1605
-CVE-2026-2332
-CVE-2026-33117
-CVE-2026-33845
-CVE-2026-33846
-CVE-2026-33870
-CVE-2026-33871
-CVE-2026-40356
-CVE-2026-42009
-CVE-2026-42010
-CVE-2026-42579
-CVE-2026-42583
-CVE-2026-42584
-CVE-2026-42587
-CVE-2026-4519
-CVE-2026-4786
-CVE-2026-4878
-CVE-2026-6100
+CVE-2026-44249
+CVE-2026-45416
+CVE-2026-45447
+CVE-2026-45674
+CVE-2026-47691
+CVE-2026-50010
+CVE-2026-54512
+CVE-2026-54513
+GHSA-2r2c-cx56-8933
+GHSA-47qp-hqvx-6r3f
 
 # Fixed in urllib3 2.7.0, but not supported in Python 3.9 which is present on the base image.
 CVE-2026-44431

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,18 @@
 
 ## Unreleased
 
+### Fix
+
+* More allowed vulnerabilities. [Ben Dalling]
+
+* Update Git Flow workflow. [Ben Dalling]
+
+* Bump azure-messaging-servicebus from 7.17.16 to 7.17.18. [Ben Dalling]
+
+* Bump base image tag for confluentinc/cp-kafka-connect from 8.2.1 to 8.2.2. [Ben Dalling]
+
 ### Build
 
-* Bump ghcr.io/devcontainers/features/docker-in-docker. [dependabot[bot]]
-
-  Bumps ghcr.io/devcontainers/features/docker-in-docker from 3.1.0 to 4.0.0.
-
-  ---
-  updated-dependencies:
-  - dependency-name: ghcr.io/devcontainers/features/docker-in-docker
-    dependency-version: 4.0.0
 * Bump actions/checkout from 6 to 7. [dependabot[bot]]
 
   Bumps [actions/checkout](https://github.com/actions/checkout) from 6 to 7.
@@ -24,6 +26,18 @@
   updated-dependencies:
   - dependency-name: actions/checkout
     dependency-version: '7'
+    dependency-type: direct:production
+    update-type: version-update:semver-major
+  ...
+
+* Bump ghcr.io/devcontainers/features/docker-in-docker. [dependabot[bot]]
+
+  Bumps ghcr.io/devcontainers/features/docker-in-docker from 3.1.0 to 4.0.0.
+
+  ---
+  updated-dependencies:
+  - dependency-name: ghcr.io/devcontainers/features/docker-in-docker
+    dependency-version: 4.0.0
     dependency-type: direct:production
     update-type: version-update:semver-major
   ...
@@ -1024,3 +1038,5 @@
     dependency-type: direct:production
     update-type: version-update:semver-major
   ...
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## Unreleased
+## 1.0.6 (2026-06-03)
 
 ### Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 
+## Unreleased
+
+### Build
+
+* Bump actions/checkout from 6 to 7. [dependabot[bot]]
+
+  Bumps [actions/checkout](https://github.com/actions/checkout) from 6 to 7.
+  - [Release notes](https://github.com/actions/checkout/releases)
+  - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
+  - [Commits](https://github.com/actions/checkout/compare/v6...v7)
+
+  ---
+  updated-dependencies:
+  - dependency-name: actions/checkout
+    dependency-version: '7'
+    dependency-type: direct:production
+    update-type: version-update:semver-major
+  ...
+
+
 ## 1.0.6 (2026-06-03)
 
 ### Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 
+## Unreleased
+
+### Build
+
+* Bump ghcr.io/devcontainers/features/docker-in-docker. [dependabot[bot]]
+
+  Bumps ghcr.io/devcontainers/features/docker-in-docker from 3.1.0 to 4.0.0.
+
+  ---
+  updated-dependencies:
+  - dependency-name: ghcr.io/devcontainers/features/docker-in-docker
+    dependency-version: 4.0.0
+    dependency-type: direct:production
+    update-type: version-update:semver-major
+  ...
+
+
 ## 1.0.6 (2026-06-03)
 
 ### Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect:8.2.1
+FROM confluentinc/cp-kafka-connect:8.2.2
 
 LABEL org.opencontainers.image.description="A Kafka Connect Sink Connecter for Azure Service Bus."
 

--- a/azure-servicebus-sink-connector/pom.xml
+++ b/azure-servicebus-sink-connector/pom.xml
@@ -17,7 +17,7 @@
     <url>https://github.com/cbdq-io/kc-connectors</url>
 
     <properties>
-        <servicebus.version>7.17.16</servicebus.version>
+        <servicebus.version>7.17.18</servicebus.version>
     </properties>
 
     <build>

--- a/azure-servicebus-sink-connector/pom.xml
+++ b/azure-servicebus-sink-connector/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.cbdq</groupId>
         <artifactId>azure-servicebus-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
 
     <artifactId>azure-servicebus-sink-connector</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.cbdq</groupId>
     <artifactId>azure-servicebus-parent</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <packaging>pom</packaging>
 
     <name>Azure Service Bus Connectors</name>


### PR DESCRIPTION
### Fix

* More allowed vulnerabilities (see #290). [Ben Dalling]

* Update Git Flow workflow. [Ben Dalling]

* Bump azure-messaging-servicebus from 7.17.16 to 7.17.18. [Ben Dalling]

* Bump base image tag for confluentinc/cp-kafka-connect from 8.2.1 to 8.2.2. [Ben Dalling]

### Build

* Bump actions/checkout from 6 to 7. [dependabot[bot]]

  Bumps [actions/checkout](https://github.com/actions/checkout) from 6 to 7.
  - [Release notes](https://github.com/actions/checkout/releases)
  - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/actions/checkout/compare/v6...v7)

  ---
  updated-dependencies:
  - dependency-name: actions/checkout
    dependency-version: '7'
    dependency-type: direct:production
    update-type: version-update:semver-major
  ...

* Bump ghcr.io/devcontainers/features/docker-in-docker. [dependabot[bot]]

  Bumps ghcr.io/devcontainers/features/docker-in-docker from 3.1.0 to 4.0.0.

  ---
  updated-dependencies:
  - dependency-name: ghcr.io/devcontainers/features/docker-in-docker
    dependency-version: 4.0.0
    dependency-type: direct:production
    update-type: version-update:semver-major
  ...